### PR TITLE
Explicit integers in filter_by_quadkey

### DIFF
--- a/R/filter_by_quadkey.R
+++ b/R/filter_by_quadkey.R
@@ -1,6 +1,6 @@
 as_binary <- function(x) {
   tmp <- rev(as.integer(intToBits(x)))
-  id <- seq_len(match(1, tmp, length(tmp)) - 1)
+  id <- seq_len(match(1L, tmp, length(tmp)) - 1L)
   tmp[-id]
 }
 
@@ -8,7 +8,7 @@ deg2num <- function(lat_deg, lon_deg, zoom) {
   lat_rad <- lat_deg * pi / 180
   n <- 2.0^zoom
   xtile <- floor((lon_deg + 180.0) / 360.0 * n)
-  ytile <- floor((1.0 - log(tan(lat_rad) + (1 / cos(lat_rad))) / pi) / 2.0 * n)
+  ytile <- floor((1.0 - log(tan(lat_rad) + (1L / cos(lat_rad))) / pi) / 2.0 * n)
   c(xtile, ytile)
 }
 
@@ -16,18 +16,18 @@ deg2num <- function(lat_deg, lon_deg, zoom) {
 # https://developer.here.com/documentation/traffic/dev_guide/common/map_tile/topics/quadkeys.html
 
 tileXYToQuadKey <- function(xTile, yTile, z) {
-  quadKey <- ""
-  for (i in z:1) {
-    digit <- 0
-    mask <- bitwShiftL(1, i - 1)
+  quadKey <- character(length(0L))
+  for (i in z:1L) {
+    digit <- 0L
+    mask <- bitwShiftL(1L, i - 1L)
     xtest <- as_binary(bitwAnd(xTile, mask))
     if (any(xtest)) {
-      digit <- digit + 1
+      digit <- digit + 1L
     }
 
     ytest <- as_binary(bitwAnd(yTile, mask))
     if (any(ytest)) {
-      digit <- digit + 2
+      digit <- digit + 2L
     }
     quadKey <- paste0(quadKey, digit)
   }
@@ -63,9 +63,9 @@ filter_by_quadkey <- function(tiles, bbox) {
     bbox <- sf::st_bbox(sf::st_transform(sf::st_as_sfc(bbox), 4326))
   }
 
-  tile_grid <- slippymath::bbox_to_tile_grid(bbox, zoom = 16)
+  tile_grid <- slippymath::bbox_to_tile_grid(bbox, zoom = 16L)
 
-  quadkeys <- mapply(tileXYToQuadKey, xTile = tile_grid$tiles$x, yTile = tile_grid$tiles$y, MoreArgs = list(z = 16))
+  quadkeys <- mapply(tileXYToQuadKey, xTile = tile_grid$tiles$x, yTile = tile_grid$tiles$y, MoreArgs = list(z = 16L))
 
   tiles[tiles$quadkey %in% quadkeys, ]
 }


### PR DESCRIPTION
This function is quite slow right now. Because of the number of looping conversions, any tiny overhead that can be reduced will improve overall performance. In this case, explicitly defining integers as such reduces overhead slightly within each loop. In my tests, this leads to about a 5% improvement in time required for the filtering function to work.


```
oot <- get_performance_tiles(service = "mobile", year = 2020, quarter = 1, col_select = c("quadkey", "avg_d_kbps"))
nc <- sf::st_read(system.file("gpkg/nc.gpkg", package="sf"), quiet = TRUE)
snc <- nc[1,]

> identical(filter_by_quadkey(oot, bbox = sf::st_bbox(snc)),
+           filter_by_quadkey2(oot, bbox = sf::st_bbox(snc)))
[1] TRUE

> microbenchmark(
+   filter_by_quadkey(oot, bbox = sf::st_bbox(snc)),
+   filter_by_quadkey2(oot, bbox = sf::st_bbox(snc)),
+   times = 100
+ )
Unit: seconds
                                             expr      min       lq     mean   median       uq      max neval
  filter_by_quadkey(oot, bbox = sf::st_bbox(snc)) 5.320194 6.301838 6.648411 6.600577 7.102319 7.944158   100
 filter_by_quadkey2(oot, bbox = sf::st_bbox(snc)) 5.065415 6.160938 6.390975 6.385587 6.867021 7.405329   100
 ```