### PR TITLE
Add parallelism to speed up filter_by_quadkey

### DIFF
--- a/man/filter_by_quadkey.Rd
+++ b/man/filter_by_quadkey.Rd
@@ -4,12 +4,16 @@
 \alias{filter_by_quadkey}
 \title{Filter Tiles by Quadkey}
 \usage{
-filter_by_quadkey(tiles, bbox)
+filter_by_quadkey(tiles, bbox, parallel = FALSE, ncores = NULL)
 }
 \arguments{
 \item{tiles}{From \code{get_performance_tiles()}}
 
 \item{bbox}{\code{\link[sf:st_bbox]{sf::st_bbox()}} bounding box describing area from which to include tiles.}
+
+\item{parallel}{Enables use of a parallel backend using \code{\link[parallel:mclapply]{parallel::mcmapply()}}. Turned off by default. This setting is not recommended for use on Windows machines.}
+
+\item{ncores}{Explicitly set number of cores to use if using \code{\link[parallel:mclapply]{parallel::mcmapply()}} is enabled. Will otherwise default the max available minus 1.}
 }
 \value{
 A filtered version of the \code{tiles} input
@@ -23,7 +27,8 @@ A filtered version of the \code{tiles} input
 filter_by_quadkey(tiles, bbox = sf::st_bbox(c(xmin = 16.1, xmax = 16.6, ymax = 48.6, ymin = 47.9), crs = st_crs(4326)))
 
 # Filters tiles to a bounding box specified by an `sf` object
-nc <- st_read(system.file("gpkg/nc.gpkg", package="sf"), quiet = TRUE)
+nc <- st_read(system.file("gpkg/nc.gpkg", package = "sf"), quiet = TRUE)
 filter_by_quadkey(tiles, bbox = sf::st_bbox(nc))
 }
+
 }


### PR DESCRIPTION
This PR adds the option for users to use parallelism via the built-in `parallel::mcmapply` function as a drop-in replacement for `mapply` in `filter_by_quadkey`. This significantly speeds up running `filter_by_quadkey`:

```r
oot <- get_performance_tiles(service = "mobile", year = 2020, quarter = 1, col_select = c("quadkey", "avg_d_kbps"))
nc <- sf::st_read(system.file("gpkg/nc.gpkg", package="sf"), quiet = TRUE)
snc <- nc[1,] # a reduced geo object for quicker tests

ncoot <- filter_by_quadkey(oot, bbox = sf::st_bbox(snc))
ncoot_par <- filter_by_quadkey_par(oot, bbox = sf::st_bbox(snc), parallel = TRUE)

> identical(ncoot, ncoot_par)
[1] TRUE

par_mb <- microbenchmark(
  filter_by_quadkey(oot, bbox = sf::st_bbox(snc)),
  filter_by_quadkey_par(oot, bbox = sf::st_bbox(snc), parallel = TRUE),
  times = 100
)

> par_mb
Unit: seconds
                                                                 expr      min       lq    mean   median       uq      max neval
                      filter_by_quadkey(oot, bbox = sf::st_bbox(snc)) 5.690945 6.617803 6.88801 6.880184 7.212670 7.915984   100
 filter_by_quadkey_par(oot, bbox = sf::st_bbox(snc), parallel = TRUE) 1.967439 2.589206 3.22361 3.018073 3.635814 7.065481   100
```
![image](https://user-images.githubusercontent.com/5847527/103324328-0b41d600-4a82-11eb-8a29-87d6a541e9fc.png)

The function`filter_by_quadkey` takes the same `tiles` and `bbox` args and adds two more: `parallel = FALSE` and `ncores = NULL)`. Parallelism is turned off by default because R's built in `parallel` often causes issues on Windows machines. A check of the operating system is triggered and returns a warning on Windows machines.

The original function is revised with a conditional flow depending on whether parallelism is enabled. When set to `TRUE`, the original logic is replaced like this:
```r
if(!parallel) {
    quadkeys <- mapply(tileXYToQuadKey, xTile = tile_grid$tiles$x, yTile = tile_grid$tiles$y, MoreArgs = list(z = 16L))
  } else {
    quadkeys <- parallel::mcmapply(tileXYToQuadKey, xTile = tile_grid$tiles$x, yTile = tile_grid$tiles$y, MoreArgs = list(z = 16L),
                         SIMPLIFY = TRUE, USE.NAMES = TRUE,
                         mc.preschedule = TRUE, mc.set.seed = TRUE,
                         mc.silent = FALSE, mc.cores = ncores, mc.cleanup = TRUE)
```
If parallelism is selected, the number of active threads is set to max available minus one using `parallel::detectCores()`. This can be overriden using the `ncores` argument in the function. 